### PR TITLE
Fix code block syntax highlighting in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -245,7 +245,7 @@ nssm remove cv4pve-botgram confirm
 
 For Linux systems, create a systemd service file.
 
-```bash
+```ini
 # Create service file
 sudo nano /etc/systemd/system/cv4pve-botgram.service
 


### PR DESCRIPTION
## Summary
- Change code block syntax from `bash` to `ini` for systemd service file example for proper syntax highlighting

## Test plan
- Review README rendering on GitHub